### PR TITLE
Updated Code Style

### DIFF
--- a/include/commands/appendcmd.h
+++ b/include/commands/appendcmd.h
@@ -1,13 +1,10 @@
 /* author: Shelby Hendrickx */
-#ifndef APPEND_COMMAND_H
-#define APPEND_COMMAND_H
+#pragma once
 #include "command.h"
 
-class AppendCommand : public Command 
+class AppendCommand : public Command
 {
 public:
     int execute(TextList& text, const SString& str) override;
     AppendCommand();
 };
-
-#endif // APPEND_COMMAND_H

--- a/include/commands/command.h
+++ b/include/commands/command.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef COMMAND_H
-#define COMMAND_H
+#pragma once
 #include "../sstring.h"
 #include "../textlist.h"
 
@@ -8,7 +7,7 @@ class Command {
 public:
     /**
      * Executes the command
-     * Returns the result code of the method 
+     * Returns the result code of the method
      */
     virtual int execute(TextList& text, const SString& str) = 0;
 
@@ -17,5 +16,3 @@ public:
      */
     //virtual ~Command();
 };
-
-#endif // COMMAND_H

--- a/include/commands/commandfactory.h
+++ b/include/commands/commandfactory.h
@@ -1,14 +1,11 @@
 /* author: Shelby Hendrickx */
-#ifndef COMMAND_FACTORY_H
-#define COMMAND_FACTORY_H
+#pragma once
 #include "command.h"
 #include "../sstring.h"
 #include "../textlist.h"
 
-class CommandFactory 
+class CommandFactory
 {
     public:
         static Command* getCommand(const TextList& gui, const SString& line);
 };
-
-#endif // COMMAND_FACTORY_H

--- a/include/commands/deletecmd.h
+++ b/include/commands/deletecmd.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef DELETE_COMMAND_H
-#define DELETE_COMMAND_H
+#pragma once
 #include "command.h"
 
 class DeleteCommand : public Command
@@ -9,5 +8,3 @@ public:
     int execute(TextList& text, const SString& str) override;
     DeleteCommand();
 };
-
-#endif // DELETE_COMMAND_H

--- a/include/commands/extendcmd.h
+++ b/include/commands/extendcmd.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef EXTEND_COMMAND_H
-#define EXTEND_COMMANDH
+#pragma once
 #include "command.h"
 
 class ExtendCommand : public Command
@@ -9,5 +8,3 @@ public:
     int execute(TextList& text, const SString& str) override;
     ExtendCommand();
 };
-
-#endif // EXTEND_COMMAND_H

--- a/include/commands/helpcmd.h
+++ b/include/commands/helpcmd.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef HELP_COMMAND_H
-#define HELP_COMMAND_H
+#pragma once
 #include "command.h"
 
 class HelpCommand : public Command
@@ -9,5 +8,3 @@ public:
     int execute(TextList& text, const SString& str) override;
     HelpCommand();
 };
-
-#endif // HELP_COMMAND_H

--- a/include/commands/insertcmd.h
+++ b/include/commands/insertcmd.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef INSERT_COMMAND_H
-#define INSERT_COMMAND_H
+#pragma once
 #include "command.h"
 
 class InsertCommand : public Command
@@ -9,5 +8,3 @@ public:
     int execute(TextList& text, const SString& str) override;
     InsertCommand();
 };
-
-#endif // INSERT_COMMAND_H

--- a/include/commands/loadcmd.h
+++ b/include/commands/loadcmd.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef LOAD_COMMAND_H
-#define LOAD_COMMAND_H
+#pragma once
 #include "command.h"
 
 class LoadCommand : public Command
@@ -9,5 +8,3 @@ public:
     int execute(TextList& text, const SString& str) override;
     LoadCommand();
 };
-
-#endif // LOAD_COMMAND_H

--- a/include/commands/printcmd.h
+++ b/include/commands/printcmd.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef PRINT_COMMAND_H
-#define PRINT_COMMAND_H
+#pragma once
 #include "command.h"
 
 class PrintCommand : public Command
@@ -9,5 +8,3 @@ public:
     int execute(TextList& text, const SString& str) override;
     PrintCommand();
 };
-
-#endif // PRINT_COMMAND_H

--- a/include/commands/quitcmd.h
+++ b/include/commands/quitcmd.h
@@ -1,13 +1,10 @@
 /* author: Shelby Hendrickx */
-#ifndef QUIT_COMMAND_H
-#define QUIT_COMMAND_H
+#pragma once
 #include "command.h"
 
 class QuitCommand : public Command
 {
-public: 
+public:
     int execute(TextList& text, const SString& str) override;
     QuitCommand();
 };
-
-#endif // QUIT_COMMAND_H

--- a/include/commands/savecmd.h
+++ b/include/commands/savecmd.h
@@ -1,13 +1,10 @@
 /* author: Shelby Hendrickx */
-#ifndef SAVE_COMMAND_H
-#define SAVE_COMMAND_H
+#pragma once
 #include "command.h"
 
 class SaveCommand : public Command
 {
 public:
     int execute(TextList& text, const SString& str) override;
-    SaveCommand();    
+    SaveCommand();
 };
-
-#endif // SAVE_COMMAND_H

--- a/include/editorgui.h
+++ b/include/editorgui.h
@@ -6,15 +6,13 @@
 #include "commands/command.h"
 #include "textlist.h"
 
-using namespace std;
-
 class EditorGUI
 {
     private:
 
         //Command *currentCommand = nullptr;
         TextList text;
-        ofstream file;
+        std::ofstream file;
     public:
         EditorGUI();
         EditorGUI(const char* file);

--- a/include/editorgui.h
+++ b/include/editorgui.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef EDITORGUI_H
-#define EDITORGUI_C
+#pragma once
 
 #include <fstream>
 
@@ -9,7 +8,7 @@
 
 using namespace std;
 
-class EditorGUI 
+class EditorGUI
 {
     private:
 
@@ -22,5 +21,3 @@ class EditorGUI
         virtual ~EditorGUI();
         void start();
 };
-
-#endif // EDITORGUI

--- a/include/linenode.h
+++ b/include/linenode.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef LINENODE_H
-#define LINENODE_H
+#pragma once
 #include "sstring.h"
 
 /**
@@ -16,23 +15,21 @@ public:
 
     /**
      * Returns next node
-     */ 
+     */
     LineNode* getNext() const;
 
     /**
      * Get data
-     */ 
+     */
     SString getData() const;
 
     /**
      * Sets node as next
-     */ 
+     */
     void appendNextNode(LineNode *node);
 
     /**
      * Prints data
-     */ 
+     */
     void printLine() const;
 };
-
-#endif // LINENODE_H

--- a/include/sstring.h
+++ b/include/sstring.h
@@ -1,6 +1,5 @@
 /* author: Shelby Hendrickx */
-#ifndef SSTRING_H
-#define SSTRING_H
+#pragma once
 #include <cstring>
 
 /**
@@ -19,12 +18,12 @@ public:
 
     /**
      * Copy constructor
-     */ 
+     */
     SString(const SString& other);
 
     /**
      * Move constructor
-     */ 
+     */
     //SString(SString&& other);
 
     /**
@@ -52,5 +51,3 @@ public:
      */
     SString operator+(const SString& str) const;
 };
-
-#endif // SSTRING_H

--- a/include/textlist.h
+++ b/include/textlist.h
@@ -1,13 +1,12 @@
 /* author: Shelby Hendrickx */
-#ifndef TEXTLIST_H
-#define TEXTLIST_H
+#pragma once
 #include <cstring>
 #include "sstring.h"
 #include "linenode.h"
 
 /**
  * Container for the full text file
- */ 
+ */
 class TextList
 {
     private:
@@ -21,7 +20,7 @@ class TextList
     public:
         /**
          * Default constructor
-         */ 
+         */
         TextList();
 
         /**
@@ -31,12 +30,12 @@ class TextList
 
         /**
          * Appends parameter s as a new line to the text file.
-         */ 
+         */
         void appendLine(const SString& str);
 
         /**
          * Prints all lines
-         */ 
+         */
         void printAll();
 
         /**
@@ -46,15 +45,13 @@ class TextList
 
         /**
          * Returns number of lines in the text file
-         */ 
+         */
         size_t numberOfLines() const;
 
         /**
          * Inserts parameter s at line n pushing back previously existing lines
-         */ 
+         */
         void insertLine(const SString& str, const size_t n);
 
         void deleteLine(const size_t line);
 };
-
-#endif // TEXTLIST_H

--- a/src/commands/appendcmd.cpp
+++ b/src/commands/appendcmd.cpp
@@ -5,18 +5,17 @@
 #include "../../include/commands/appendcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 AppendCommand::AppendCommand()
 {}
 
 int AppendCommand::execute(TextList& text, const SString& str)
 {
-    string line;
+    std::string line;
     bool isInvalid = true;
-    while (isInvalid) 
+    while (isInvalid)
     {
-        cin >> line;
+        std::cin >> line;
         if (line.length() <= 80) isInvalid = false;
     }
 

--- a/src/commands/deletecmd.cpp
+++ b/src/commands/deletecmd.cpp
@@ -5,7 +5,6 @@
 #include "../../include/commands/deletecmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 DeleteCommand::DeleteCommand()
 {}
@@ -14,4 +13,3 @@ int DeleteCommand::execute(TextList& text, const SString& cmd)
 {
     return 0;
 }
-

--- a/src/commands/extendcmd.cpp
+++ b/src/commands/extendcmd.cpp
@@ -2,7 +2,6 @@
 #include "../../include/commands/extendcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 ExtendCommand::ExtendCommand()
 {}

--- a/src/commands/helpcmd.cpp
+++ b/src/commands/helpcmd.cpp
@@ -2,7 +2,6 @@
 #include "../../include/commands/helpcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 HelpCommand::HelpCommand()
 {}

--- a/src/commands/insertcmd.cpp
+++ b/src/commands/insertcmd.cpp
@@ -5,7 +5,6 @@
 #include "../../include/commands/insertcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 InsertCommand::InsertCommand()
 {}
@@ -15,7 +14,7 @@ int InsertCommand::execute(TextList& text, const SString& cmd)
     if (cmd.getLength() > 1)
     {
         // get number after first char (e.g.: with p352 we would need 352)
-        size_t line = atol(cmd.getData() + 1); 
+        size_t line = atol(cmd.getData() + 1);
         text.printLine(line);
     }
     else
@@ -25,4 +24,3 @@ int InsertCommand::execute(TextList& text, const SString& cmd)
     }
     return 0;
 }
-

--- a/src/commands/loadcmd.cpp
+++ b/src/commands/loadcmd.cpp
@@ -2,7 +2,6 @@
 #include "../../include/commands/loadcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 LoadCommand::LoadCommand()
 {}

--- a/src/commands/printcmd.cpp
+++ b/src/commands/printcmd.cpp
@@ -5,7 +5,6 @@
 #include "../../include/commands/printcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 PrintCommand::PrintCommand()
 {}
@@ -15,7 +14,7 @@ int PrintCommand::execute(TextList& text, const SString& cmd)
     if (cmd.getLength() > 1)
     {
         // get number after first char (e.g.: with p352 we would need 352)
-        size_t line = atol(cmd.getData() + 1); // todo change sstring 
+        size_t line = atol(cmd.getData() + 1); // todo change sstring
         text.printLine(line);
     }
     else
@@ -25,4 +24,3 @@ int PrintCommand::execute(TextList& text, const SString& cmd)
     }
     return 0;
 }
-

--- a/src/commands/quitcmd.cpp
+++ b/src/commands/quitcmd.cpp
@@ -2,7 +2,6 @@
 #include "../../include/commands/quitcmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 QuitCommand::QuitCommand()
 {}

--- a/src/commands/savecmd.cpp
+++ b/src/commands/savecmd.cpp
@@ -2,7 +2,6 @@
 #include "../../include/commands/savecmd.h"
 #include "../../include/sstring.h"
 #include "../../include/textlist.h"
-using namespace std;
 
 SaveCommand::SaveCommand()
 {}

--- a/src/editorgui.cpp
+++ b/src/editorgui.cpp
@@ -9,26 +9,24 @@
 #include "../include/commands/commandfactory.h"
 #include "../include/commands/command.h"
 
-using namespace std;
-
 EditorGUI::EditorGUI()
     :text{text}
 {
-    string fileName;
-    cout << "Enter file name: ";
-    getline(cin, fileName);
+    std::string fileName;
+    std::cout << "Enter file name: ";
+    std::getline(cin, fileName);
     file.open(fileName);
 }
 
 EditorGUI::EditorGUI(const char* file)
 {
-    ifstream fs(file);
+    std::ifstream fs(file);
     if (!fs.is_open()) return;
-    string line;
-    while (!fs.eof()) 
+    std::string line;
+    while (!fs.eof())
     {
         SString sline(line.c_str());
-        getline(fs, line);
+        std::getline(fs, line);
         text.appendLine(sline);
     }
 }
@@ -43,22 +41,20 @@ void EditorGUI::start()
     bool running = true;
     while(running)
     {
-        cout << "*";
-        string line;
-        getline(cin, line);
+        std::cout << "*";
+        std::string line;
+        std::getline(cin, line);
 
         SString *sline = new SString(line.c_str());
-        
+
         Command *cmd = CommandFactory::getCommand(text, sline->getData());
         //currentCommand = cmd;
 
         int result = cmd->execute(text, *sline);
         if (result == -1)
-            cout << "Unhandled exception" << endl;
-        
+            std::cout << "Unhandled exception" << std::endl;
+
         delete cmd;
         delete sline;
     }
 }
-
- 

--- a/src/linenode.cpp
+++ b/src/linenode.cpp
@@ -1,7 +1,6 @@
 /* author: Shelby Hendrickx */
 #include <iostream>
 #include "../include/linenode.h"
-using namespace std;
 
 LineNode::LineNode(const SString& str)
     :data{str}, next{nullptr}
@@ -27,6 +26,5 @@ SString LineNode::getData() const
 void LineNode::printLine() const
 {
     data.print();
-    cout << endl;
+    std::cout << endl;
 }
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,24 +1,23 @@
 /* author: Shelby Hendrickx */
 #include <iostream>
 #include "../include/editorgui.h"
-using namespace std;
 
 int main(int argc, char* argv[])
 {
     // TODO if filename not provided create new file
 
-    cout << "Welcome to Edline" << endl;
+    std::cout << "Welcome to Edline" << std::endl;
 
-    if (argc == 2) 
+    if (argc == 2)
     {
-        cout << "Starting application with file: " <<  argv[1] << endl;
+        std::cout << "Starting application with file: " <<  argv[1] << std::endl;
         EditorGUI(argv[1]).start();
     }
-    else 
+    else
     {
-        cout << "Starting application" << endl;
+        std::cout << "Starting application" << std::endl;
         EditorGUI().start();
     }
-    
+
     return 0;
 }

--- a/src/sstring.cpp
+++ b/src/sstring.cpp
@@ -2,14 +2,13 @@
 #include <iostream>
 #include <string.h>
 #include "../include/sstring.h"
-using namespace std;
 
 SString::SString(const char* str)
     :str{str}, len{strlen(str)}
 { }
 
-SString::SString(const SString& str) 
-    :str{str.str}, len{str.len} 
+SString::SString(const SString& str)
+    :str{str.str}, len{str.len}
 { }
 
 SString::~SString() {}
@@ -26,7 +25,7 @@ const char* SString::getData() const
 
 void SString::print() const
 {
-    cout << str;
+    std::cout << str;
 }
 
 SString SString::operator+(const SString& str) const


### PR DESCRIPTION
## Issues
1. Usage of `using namespace std;`
1. Using C-Style include guards

## Proposed Solutions
1. Removed `using namespace std;` and added `std::` where it is necessary
1. Replaced old include guards with `#pragma once`

## Reasoning
1. `using namespace std;` can easily cause ambiguity if classes like `std::string` are re-implemented in another library. Therefore, usage of `using namespace std;` is highly discouraged
1. C-Style include guard names may collide if their names are not properly chosen and multiple implementations of a similar item are given